### PR TITLE
Fixed issue #326

### DIFF
--- a/src/mcp/client/stdio.py
+++ b/src/mcp/client/stdio.py
@@ -103,7 +103,7 @@ async def stdio_client(server: StdioServerParameters):
 
     process = await anyio.open_process(
         [server.command, *server.args],
-        env=server.env if server.env is not None else get_default_environment(),
+        env={**get_default_environment(), **server.env} if server.env is not None else get_default_environment(),
         stderr=sys.stderr,
         cwd=server.cwd,
     )


### PR DESCRIPTION
Fixed issue #326 - MCP client with npx not working when env parameter of StdioServerParameters is set